### PR TITLE
Move 'with profile' in order to use right profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ your Procfile. This will cause Leiningen to calculate the classpath
 and code to run for your project, then exit and execute your project's
 JVM:
 
-    web: lein trampoline with-profile production run -m myapp.web
+    web: lein with-profile production trampoline run -m myapp.web
 
 ## Hacking
 


### PR DESCRIPTION
When 'with profile production' is placed after trampoline, 
development dependencies are still being fetched.

In the leiningen 2 branch this happens to have the right order already.
See https://github.com/heroku/heroku-buildpack-clojure/blob/lein-2/README.md#74
