### PR TITLE
Escape $HOME to delay evaluation until runtime.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -137,7 +137,7 @@ mkdir -p $(dirname $PROFILE_PATH)
 
 echo "export JVM_OPTS=\"\${JVM_OPTS:--Xmx400m -Dfile.encoding=UTF-8}\"" >> $PROFILE_PATH
 echo "export LEIN_NO_DEV=\"\${LEIN_NO_DEV:-yes}\"" >> $PROFILE_PATH
-echo "export PATH=\"$HOME/.jdk/bin:$PATH:\$HOME/.lein/bin\"" >> $PROFILE_PATH
+echo "export PATH=\"\$HOME/.jdk/bin:$PATH:\$HOME/.lein/bin\"" >> $PROFILE_PATH
 
 # default Procfile
 if [ ! -r $BUILD_DIR/Procfile ]; then


### PR DESCRIPTION
I'm using your buildpack on a Cloud Foundry instance instead of Heroku. It looks like `HOME` may not be escaped properly when configuring environment variables in `.profile.d/clojure.sh`.

When the `compile` script is run on Cloud Foundry, `HOME` is set to `/home/vcap`, but when the app is started up it's (correctly) set to `/home/vcap/app`. So, Leiningen's `bin` directory is correctly added to `PATH`, but Java's isn't (since `HOME` was expanded when `compile` wrote `clojure.sh`).

For example, here's what `clojure.sh` looked like before this patch.

``` bash
export JVM_OPTS="${JVM_OPTS:--Xmx400m -Dfile.encoding=UTF-8}"
export LEIN_NO_DEV="${LEIN_NO_DEV:-yes}"
export PATH="/home/vcap/.jdk/bin:/home/vcap/.jdk/bin:/tmp/staged/app/.jdk//bin:/bin:/usr/bin:$HOME/.lein/bin"
```

(`/home/vcap/.jdk/` doesn't exist.)

I haven't tested this on Heroku, but this should work since this patch just causes the Java path modifications to work the same way as Leningen's.
