### PR TITLE
Bump heap size to 1gb

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -124,7 +124,7 @@ fi
 echo "       Running: $BUILD_COMMAND"
 
 cd $BUILD_DIR
-PATH=.lein/bin:$PATH LEIN_JVM_OPTS="-Xmx500m -Duser.home=$BUILD_DIR" \
+PATH=.lein/bin:$PATH LEIN_JVM_OPTS="-Xmx1024m -Duser.home=$BUILD_DIR" \
   $BUILD_COMMAND 2>&1 | sed -u 's/^/       /'
 if [ "${PIPESTATUS[*]}" != "0 0" ]; then
   echo " !     Failed to build."


### PR DESCRIPTION
Builds are run in 2X dynos and can take advantage of a larger heap size. This brings Clojure in line with the Java and Scala buildpacks.
