### PR TITLE
App’s PATH not overwritten with build env PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -157,7 +157,7 @@ mkdir -p $(dirname $PROFILE_PATH)
 
 echo "export JVM_OPTS=\"\${JVM_OPTS:--Xmx400m -Dfile.encoding=UTF-8}\"" >> $PROFILE_PATH
 echo "export LEIN_NO_DEV=\"\${LEIN_NO_DEV:-yes}\"" >> $PROFILE_PATH
-echo "export PATH=\"\$HOME/.jdk/bin:$PATH:\$HOME/.lein/bin\"" >> $PROFILE_PATH
+echo 'export PATH="$HOME/.jdk/bin:$HOME/.lein/bin:$PATH"' >> $PROFILE_PATH
 
 # default Procfile
 if [ ! -r $BUILD_DIR/Procfile ]; then


### PR DESCRIPTION
The PATH generated by the buildpack previously overwrote the system’s existing PATH.  The new behavior is to prepend the desired additions to that existing PATH.

Including the build environment's $PATH in the export is not desirable, as the result includes directories which will not exist on release:

```
export PATH="$HOME/.jdk/bin:/app/.jdk/bin:/tmp/build_8c0d5152-61a4-4e72-8bae-0574f014ba4f/.jdk//bin::/tmp/codon/vendor/bin:/usr/ruby1.9.2/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/.lein/bin"
```

Better to explicitly declare only the custom paths.

This is the same methodology used by other buildpacks:
- https://github.com/heroku/heroku-buildpack-scala/blob/37723c214e860d9cfab46a75cb9ad54bc82fbcb8/bin/compile#L127
- https://github.com/heroku/heroku-buildpack-python/blob/7ec8f126488fbadfad58ebee95b3a4443f3d238e/bin/compile#L245
- https://github.com/heroku/heroku-buildpack-nodejs/blob/a8b31de496ce56d7c8218efa4a680d42df23beeb/bin/compile#L137

Resulting PATH after change:

```
$ heroku run 'echo $PATH'
Running `echo $PATH` attached to terminal... up, run.8577
/app/.jdk/bin:/app/.lein/bin:/usr/local/bin:/usr/bin:/bin
```
