### PR TITLE
PATH not being set correctly in clojure.sh in profile.d

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -157,7 +157,7 @@ mkdir -p $(dirname $PROFILE_PATH)
 
 echo "export JVM_OPTS=\"\${JVM_OPTS:--Xmx400m -Dfile.encoding=UTF-8}\"" >> $PROFILE_PATH
 echo "export LEIN_NO_DEV=\"\${LEIN_NO_DEV:-yes}\"" >> $PROFILE_PATH
-echo "export PATH=\"\$HOME/.jdk/bin:$PATH:\$HOME/.lein/bin\"" >> $PROFILE_PATH
+echo "export PATH=\"\$HOME/.jdk/bin:\$PATH:\$HOME/.lein/bin\"" >> $PROFILE_PATH
 
 # default Procfile
 if [ ! -r $BUILD_DIR/Procfile ]; then


### PR DESCRIPTION
The `$` in `$PATH` wasn't being escaped in `export PATH`. This is causing issues when using with other buildpacks via heroku-buildpack-multi that need to add on to the PATH environment variable.

What clojure.sh looks like **with** the fix:

``` bash
export JVM_OPTS="${JVM_OPTS:--Xmx400m -Dfile.encoding=UTF-8}"
export LEIN_NO_DEV="${LEIN_NO_DEV:-yes}"
export PATH="$HOME/.jdk/bin:$PATH:$HOME/.lein/bin"
```

What clojure.sh looks like **without** the fix:

``` bash
export JVM_OPTS="${JVM_OPTS:--Xmx400m -Dfile.encoding=UTF-8}"
export LEIN_NO_DEV="${LEIN_NO_DEV:-yes}"
export PATH="$HOME/.jdk/bin:/app/.jdk/bin:/tmp/build_2307d86b-2ac8-44dc-8bb0-53c63d58aece/.jdk//bin::/tmp/codon/vendor/bin:/app/bin:/usr/ruby1.9.2/bin:/usr/local/bin:/usr
/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/.lein/bin"
```
