### PR TITLE
change path to match whats in tar

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ export ENV_DIR=$3
 
 # Load common JVM functionality from https://github.com/heroku/heroku-buildpack-jvm-common
 JVM_COMMON_BUILDPACK=http://lang-jvm.s3.amazonaws.com/jvm-buildpack-common-v3.tar.gz
-curl --silent --location $JVM_COMMON_BUILDPACK | tar -x bin/java -zO > /tmp/jvm-common
+curl --silent --location $JVM_COMMON_BUILDPACK | tar -x ./bin/java -zO > /tmp/jvm-common
 source /tmp/jvm-common
 
 # JDK version


### PR DESCRIPTION
The tar as provided changed it's paths from bin/java to ./bin/java causing problems during compilation.
