### PR TITLE
Download nodejs over HTTPS

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -19,8 +19,8 @@ install_nodejs() {
   local cpu="x64"
 
   echo "Downloading and installing node $version..."
-  local download_url="http://s3pository.heroku.com/node/v$version/node-v$version-$os-$cpu.tar.gz"
-  curl "$download_url" --silent --fail -o /tmp/node.tar.gz || (echo "Unable to download node $version; does it exist?" && false)
+  local download_url="https://s3pository.heroku.com/node/v$version/node-v$version-$os-$cpu.tar.gz"
+  curl "$download_url" --silent --show-error --fail -o /tmp/node.tar.gz || (echo "Unable to download node $version; does it exist?" && false)
   tar xzf /tmp/node.tar.gz -C /tmp
   mv /tmp/node-v$version-$os-$cpu $dir
   chmod +x $dir/bin/*


### PR DESCRIPTION
Also adjusts curl usage to output any errors rather than suppress all output.

Fixes #50.