### PR TITLE
Use nodebin to download Node.js instead of s3pository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'heroku_hatchet', '3.0.0'
+gem 'heroku_hatchet'
 gem 'rspec-retry'
 gem 'rspec-expectations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,80 +1,62 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.8)
+    activesupport (5.1.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    anvil-cli (0.16.2)
-      progress (~> 2.4, >= 2.4.0)
-      rest-client (~> 1.6, >= 1.6.7)
-      thor (~> 0.15, >= 0.15.2)
-    diff-lcs (1.2.5)
-    domain_name (0.5.20170404)
-      unf (>= 0.0.5, < 1.0.0)
+    concurrent-ruby (1.0.5)
+    diff-lcs (1.3)
     erubis (2.7.0)
-    excon (0.57.0)
-    heroics (0.0.22)
+    excon (0.59.0)
+    heroics (0.0.24)
       erubis (~> 2.0)
       excon
+      moneta
       multi_json (>= 1.9.2)
-    heroku-api (0.4.2)
-      excon (~> 0.45)
-      multi_json (~> 1.8)
-    heroku_hatchet (3.0.0)
-      activesupport (~> 4)
-      anvil-cli (~> 0)
+    heroku_hatchet (3.0.5)
       excon (~> 0)
-      heroku-api (~> 0)
+      minitest-retry (~> 0.1.9)
       platform-api (~> 2)
       repl_runner (~> 0.0.3)
       rrrretry (~> 1)
       thor (~> 0)
       threaded (~> 0)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
-    i18n (0.8.4)
-    mime-types (2.99.3)
-    minitest (5.10.2)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
+    minitest (5.10.3)
+    minitest-retry (0.1.9)
+      minitest (>= 5.0)
     moneta (0.8.1)
-    multi_json (1.12.1)
-    netrc (0.11.0)
-    platform-api (2.0.0)
-      heroics (~> 0.0.22)
+    multi_json (1.12.2)
+    platform-api (2.1.0)
+      heroics (~> 0.0.23)
       moneta (~> 0.8.1)
-    progress (2.4.0)
     repl_runner (0.0.3)
       activesupport
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rrrretry (1.0.0)
-    rspec-core (3.4.1)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-retry (0.4.5)
-      rspec-core
-    rspec-support (3.4.1)
-    thor (0.19.4)
+      rspec-support (~> 3.7.0)
+    rspec-retry (0.5.6)
+      rspec-core (> 3.3, < 3.8)
+    rspec-support (3.7.0)
+    thor (0.20.0)
     thread_safe (0.3.6)
     threaded (0.0.4)
-    tzinfo (1.2.3)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  heroku_hatchet (= 3.0.0)
+  heroku_hatchet
   rspec-expectations
   rspec-retry
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/spec/cljs_spec.rb
+++ b/spec/cljs_spec.rb
@@ -11,7 +11,7 @@ describe "ClojureScript" do
       let(:jdk_version) { version }
       it "deploy successfully" do
         app.deploy do |app|
-          expect(app.output).to include("Installing OpenJDK #{jdk_version}")
+          expect(app.output).to include("Installing JDK #{jdk_version}")
           expect(app.output).to match(/Downloading: leiningen-2.[5-9].[0-9]-standalone.jar/)
           expect(app.output).to include("Running: lein uberjar")
           sleep 3
@@ -28,7 +28,7 @@ describe "ClojureScript" do
       let(:jdk_version) { version }
       it "deploy successfully" do
         app.deploy do |app|
-          expect(app.output).to include("Installing OpenJDK #{jdk_version}")
+          expect(app.output).to include("Installing JDK #{jdk_version}")
           expect(app.output).to match(/Downloading: leiningen-2.[5-9].[0-9]-standalone.jar/)
           expect(app.output).to include("Running: lein with-profile production do deps, compile :all")
           sleep 3

--- a/spec/compojure_spec.rb
+++ b/spec/compojure_spec.rb
@@ -11,7 +11,7 @@ describe "Compojure" do
       let(:jdk_version) { version }
       it "deploy successfully" do
         app.deploy do |app|
-          expect(app.output).to include("Installing OpenJDK #{jdk_version}")
+          expect(app.output).to include("Installing JDK #{jdk_version}")
           expect(app.output).to match(/Downloading: leiningen-2.[0-9].[0-9]-standalone.jar/)
           expect(app.output).to include("Running: lein uberjar")
           expect(app).to be_deployed

--- a/spec/immutant_spec.rb
+++ b/spec/immutant_spec.rb
@@ -11,7 +11,7 @@ describe "Immutant" do
       let(:jdk_version) { version }
       it "deploys successfully" do
         app.deploy do |app|
-          expect(app.output).to include("Installing OpenJDK #{jdk_version}")
+          expect(app.output).to include("Installing JDK #{jdk_version}")
           expect(app.output).to match(/Downloading: leiningen-2.[5-9].[0-9]-standalone.jar/)
           expect(app.output).to include("Running: lein uberjar")
           expect(app.output).to include("Compiling demo.core")

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -74,7 +74,7 @@ testCompileJdk7() {
   _createSysProps "1.7"
   compile
   assertCapturedSuccess
-  assertCaptured "Installing OpenJDK 1.7... done"
+  assertCaptured "Installing JDK 1.7... done"
   assertCaptured "Downloading: leiningen-1.7.1-standalone.jar"
 }
 
@@ -82,7 +82,7 @@ testCompileJdk8() {
   _createBaseProject
   compile
   assertCapturedSuccess
-  assertCaptured "Installing OpenJDK 1.8... done"
+  assertCaptured "Installing JDK 1.8... done"
   assertCaptured "No :min-lein-version found in project.clj; using 1.7.1."
   assertCaptured "To use Leiningen 2.x, add this to project.clj: :min-lein-version \"2.0.0\""
   assertCaptured "Downloading: leiningen-1.7.1-standalone.jar"


### PR DESCRIPTION
There are some `Gemfile` changes for Hatchet tests in here, and a change to the "Installing JDK" line from `heroku/jvm`. But the primary change is in `lib/common.sh`.