### PR TITLE
Default process type for Uberjar

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -16,6 +16,7 @@ BIN_DIR=$BP_DIR/bin
 LIB_DIR=$BP_DIR/lib
 
 source $LIB_DIR/common.sh
+source $LIB_DIR/lein.sh
 source <(curl --retry 3 -fsSL $BUILDPACK_STDLIB_URL)
 
 export_env $ENV_DIR "." "JAVA_OPTS"
@@ -34,7 +35,7 @@ if [ -x $BUILD_DIR/bin/lein ]; then
   $LEIN_BIN_PATH version 2>/dev/null | sed -u 's/^/       /'
 else
   # Determine Leiningen version
-  if [ "$(grep ":min-lein-version[[:space:]]\+\"2" $BUILD_DIR/project.clj)" != "" ]; then
+  if is_lein_2 $BUILD_DIR; then
     LEIN_VERSION="2.7.1"
     LEIN_BIN_SOURCE="$(dirname $0)/../opt/lein2"
     calculate_lein_build_task $BUILD_DIR
@@ -148,17 +149,6 @@ mkdir -p $(dirname $PROFILE_PATH)
 echo "export LEIN_NO_DEV=\"\${LEIN_NO_DEV:-yes}\"" >> $PROFILE_PATH
 echo 'export PATH="$HOME/.heroku/nodejs/bin:$HOME/.jdk/bin:$HOME/.lein/bin:$PATH"' >> $PROFILE_PATH
 echo 'export RING_ENV="${RING_ENV:-production}"' >> $PROFILE_PATH
-
-# default Procfile
-if [ ! -r $BUILD_DIR/Procfile ]; then
-  if [ "$LEIN_VERSION" = "1.7.1" ]; then
-    echo "       No Procfile; using \"web: lein trampoline run\"."
-    echo "web: lein trampoline run" > $BUILD_DIR/Procfile
-  else
-    echo "       No Procfile; using \"web: lein with-profile production trampoline run\"."
-    echo "web: lein with-profile production trampoline run" > $BUILD_DIR/Procfile
-  fi
-fi
 
 # repack cache with new assets
 mkdir -p $CACHE_DIR

--- a/bin/release
+++ b/bin/release
@@ -1,11 +1,31 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
+export BUILD_DIR=$1
+
+BP_DIR=$(cd $(dirname $0)/..; pwd)
+BIN_DIR=$BP_DIR/bin
+LIB_DIR=$BP_DIR/lib
+
+source $LIB_DIR/common.sh
+source $LIB_DIR/lein.sh
+
 if [ ! -f $BUILD_DIR/Procfile ]; then
   cat <<EOF
 ---
 config_vars:
 default_process_types:
-  web: lein trampoline run
 EOF
+
+  if [ "$(calculate_lein_build_task $BUILD_DIR)" == "uberjar" ]; then
+    cd $BUILD_DIR
+    for jarFile in $(find target -maxdepth 1 -name "*.jar" -type f); do
+      echo "  web: java -jar $jarFile"
+      break
+    done
+  elif is_lein_2 $BUILD_DIR; then
+    echo "  web: lein with-profile production trampoline run"
+  else
+    echo "  web: lein trampoline run"
+  fi
 fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -2,18 +2,6 @@
 
 export BUILDPACK_STDLIB_URL="https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh"
 
-calculate_lein_build_task() {
-  local buildDir=${1}
-  if [ "$(grep :uberjar-name $buildDir/project.clj)" != "" ]; then
-    export LEIN_BUILD_TASK="${LEIN_BUILD_TASK:-uberjar}"
-    export LEIN_INCLUDE_IN_SLUG="${LEIN_INCLUDE_IN_SLUG:-no}"
-  elif [ "$(grep lein-npm $buildDir/project.clj)" != "" ]; then
-    export LEIN_BUILD_TASK=${LEIN_BUILD_TASK:-"with-profile production do deps, compile :all"}
-  else
-    export LEIN_BUILD_TASK=${LEIN_BUILD_TASK:-"with-profile production compile :all"}
-  fi
-}
-
 cache_copy() {
   rel_dir=$1
   from_dir=$2

--- a/lib/lein.sh
+++ b/lib/lein.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+calculate_lein_build_task() {
+  local buildDir=${1}
+  if [ "$(grep :uberjar-name $buildDir/project.clj)" != "" ]; then
+    export LEIN_BUILD_TASK="${LEIN_BUILD_TASK:-uberjar}"
+    export LEIN_INCLUDE_IN_SLUG="${LEIN_INCLUDE_IN_SLUG:-no}"
+  elif [ "$(grep lein-npm $buildDir/project.clj)" != "" ]; then
+    export LEIN_BUILD_TASK=${LEIN_BUILD_TASK:-"with-profile production do deps, compile :all"}
+  else
+    export LEIN_BUILD_TASK=${LEIN_BUILD_TASK:-"with-profile production compile :all"}
+  fi
+}
+
 is_lein_2() {
   local buildDir=${1}
   if [ "$(grep ":min-lein-version[[:space:]]\+\"2" $BUILD_DIR/project.clj)" != "" ]; then

--- a/lib/lein.sh
+++ b/lib/lein.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+is_lein_2() {
+  local buildDir=${1}
+  if [ "$(grep ":min-lein-version[[:space:]]\+\"2" $BUILD_DIR/project.clj)" != "" ]; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -86,7 +86,6 @@ testCompileJdk8() {
   assertCaptured "No :min-lein-version found in project.clj; using 1.7.1."
   assertCaptured "To use Leiningen 2.x, add this to project.clj: :min-lein-version \"2.0.0\""
   assertCaptured "Downloading: leiningen-1.7.1-standalone.jar"
-  assertCaptured "No Procfile; using \"web: lein trampoline run\"."
 }
 
 testMinLeinVersion() {
@@ -96,7 +95,6 @@ testMinLeinVersion() {
   assertCapturedSuccess
   assertNotCaptured "WARNING: no :min-lein-version found in project.clj; using 1.7.1."
   assertCaptured "Downloading: leiningen-2.7.1-standalone.jar"
-  assertCaptured "No Procfile; using \"web: lein with-profile production trampoline run\"."
 }
 
 testUberJar() {

--- a/test/lein_test.sh
+++ b/test/lein_test.sh
@@ -40,3 +40,46 @@ EOF
   capture is_lein_2 ${BUILD_DIR}
   assertTrue "Expected captured exit code to be greater than 0; was <${RETURN}>" "[ ${RETURN} -gt 0 ]"
 }
+
+test_calculate_lein_build_task_uberjar() {
+  unset LEIN_BUILD_TASK
+  cat > ${BUILD_DIR}/project.clj <<EOF
+(defproject clojure-getting-started "1.0.0-SNAPSHOT"
+    :description "Demo Clojure web app"
+    :url "http://clojure-getting-started.herokuapp.com"
+    :license {:name "Eclipse Public License v1.0"
+              :url "http://www.eclipse.org/legal/epl-v10.html"}
+    :dependencies [[org.clojure/clojure "1.6.0"]
+                   [compojure "1.1.8"]
+                   [ring/ring-jetty-adapter "1.2.2"]
+                   [environ "0.5.0"]]
+  :min-lein-version "2.0.0"
+  :hooks [environ.leiningen.hooks]
+  :uberjar-name "clojure-getting-started-standalone.jar"
+  :profiles {:production {:env {:production true}}})
+EOF
+  capture calculate_lein_build_task ${BUILD_DIR}
+  assertEquals "Expected uberjar build task" "uberjar" "$LEIN_BUILD_TASK"
+  assertEquals "Expected lein not included in slug" "no" "$LEIN_INCLUDE_IN_SLUG"
+  unset LEIN_BUILD_TASK
+}
+
+test_calculate_lein_build_task_production_compile() {
+  unset LEIN_BUILD_TASK
+  cat > ${BUILD_DIR}/project.clj <<EOF
+(defproject clojure-getting-started "1.0.0-SNAPSHOT"
+    :description "Demo Clojure web app"
+    :url "http://clojure-getting-started.herokuapp.com"
+    :license {:name "Eclipse Public License v1.0"
+              :url "http://www.eclipse.org/legal/epl-v10.html"}
+    :dependencies [[org.clojure/clojure "1.6.0"]
+                   [compojure "1.1.8"]
+                   [ring/ring-jetty-adapter "1.2.2"]
+                   [environ "0.5.0"]]
+  :hooks [environ.leiningen.hooks]
+  :profiles {:production {:env {:production true}}})
+EOF
+  capture calculate_lein_build_task ${BUILD_DIR}
+  assertEquals "Expected compile build task" "with-profile production compile :all" "$LEIN_BUILD_TASK"
+  unset LEIN_BUILD_TASK
+}

--- a/test/lein_test.sh
+++ b/test/lein_test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+. ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
+. ${BUILDPACK_HOME}/lib/lein.sh
+
+test_is_lein_2_positive() {
+  cat > ${BUILD_DIR}/project.clj <<EOF
+(defproject clojure-getting-started "1.0.0-SNAPSHOT"
+    :description "Demo Clojure web app"
+    :url "http://clojure-getting-started.herokuapp.com"
+    :license {:name "Eclipse Public License v1.0"
+              :url "http://www.eclipse.org/legal/epl-v10.html"}
+    :dependencies [[org.clojure/clojure "1.6.0"]
+                   [compojure "1.1.8"]
+                   [ring/ring-jetty-adapter "1.2.2"]
+                   [environ "0.5.0"]]
+  :min-lein-version "2.0.0"
+  :hooks [environ.leiningen.hooks]
+  :uberjar-name "clojure-getting-started-standalone.jar"
+  :profiles {:production {:env {:production true}}})
+EOF
+  capture is_lein_2 ${BUILD_DIR}
+  assertCapturedSuccess
+}
+
+test_is_lein_2_negative() {
+  cat > ${BUILD_DIR}/project.clj <<EOF
+(defproject clojure-getting-started "1.0.0-SNAPSHOT"
+    :description "Demo Clojure web app"
+    :url "http://clojure-getting-started.herokuapp.com"
+    :license {:name "Eclipse Public License v1.0"
+              :url "http://www.eclipse.org/legal/epl-v10.html"}
+    :dependencies [[org.clojure/clojure "1.6.0"]
+                   [compojure "1.1.8"]
+                   [ring/ring-jetty-adapter "1.2.2"]
+                   [environ "0.5.0"]]
+  :hooks [environ.leiningen.hooks]
+  :profiles {:production {:env {:production true}}})
+EOF
+  capture is_lein_2 ${BUILD_DIR}
+  assertTrue "Expected captured exit code to be greater than 0; was <${RETURN}>" "[ ${RETURN} -gt 0 ]"
+}


### PR DESCRIPTION
Added a default process type when building an uberjar. Also moved Lein functions into `lib/lein.sh` helper, and added tests.