### PR TITLE
Update Leiningen version to 2.9.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ if [ -x $BUILD_DIR/bin/lein ]; then
 else
   # Determine Leiningen version
   if is_lein_2 $BUILD_DIR; then
-    LEIN_VERSION="2.8.3"
+    LEIN_VERSION="2.9.1"
     LEIN_BIN_SOURCE="$(dirname $0)/../opt/lein2"
     calculate_lein_build_task $BUILD_DIR
   else


### PR DESCRIPTION
Version 2.9.1 works correctly with ENV variables that are set to empty string. For example having `HTTP_PROXY=""` no longer breaks install of dependencies.  

See https://github.com/technomancy/leiningen/pull/2536 