### PR TITLE
Inclusive language: Replace BUILD_CONFIG_WHITELIST with BUILD_CONFIG_ALLOWLIST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Clojure Buildpack Changelog
 
-## master
+## v85
+
+* Rename `BUILD_CONFIG_WHITELIST` to `BUILD_CONFIG_ALLOWLIST`
+
+## v84
 
 * Update default lein to 2.9.1
 

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ into production.
 In order to ensure consistent builds, normally values set with `heroku
 config:add ...` (other than `LEIN_USERNAME`, `LEIN_PASSWORD`, and
 `LEIN_PASSPHRASE`) will not be visible at compile time. To expose more
-to the compilation process, set a `BUILD_CONFIG_WHITELIST` config var
+to the compilation process, set a `BUILD_CONFIG_ALLOWLIST` config var
 containing a space-delimited list of config var names. Note that this
 can result in unpredictable behaviour since changing your app's config
 does not result in a rebuild of your app. So it's easy to get into a
 situation where your build is broken, but you don't notice it until
 later when you push. For this reason it's recommended to take care
-with this feature and always push after changing a whitelisted config
+with this feature and always push after changing a allowlisted config
 value.
 
 ### Uberjar

--- a/bin/compile
+++ b/bin/compile
@@ -118,20 +118,23 @@ done
 echo "-----> Building with Leiningen"
 
 # extract environment
-if [ -d "$ENV_DIR" ]; then
-    # if BUILD_CONFIG_WHITELIST is set, read it to know which configs to export
-    if [ -r $ENV_DIR/BUILD_CONFIG_WHITELIST ]; then
-        for e in $(cat $ENV_DIR/BUILD_CONFIG_WHITELIST); do
-            export "$e=$(cat $ENV_DIR/$e)"
-        done
-    # otherwise default BUILD_CONFIG_WHITELIST to just private repo creds
-    else
-        for e in LEIN_USERNAME LEIN_PASSWORD LEIN_PASSPHRASE; do
-            if [ -r $ENV_DIR/$e ]; then
-                export "$e=$(cat $ENV_DIR/$e)"
-            fi
-        done
-    fi
+if [ -d "${ENV_DIR}" ]; then
+  # Be default, only export private repo credentials
+  config_vars="LEIN_USERNAME LEIN_PASSWORD LEIN_PASSPHRASE"
+
+  if [ -r "${ENV_DIR}/BUILD_CONFIG_ALLOWLIST" ]; then
+    config_vars=$(cat "${ENV_DIR}/BUILD_CONFIG_ALLOWLIST")
+
+  # Backwards compatibility for legacy configuration
+  elif [ -r "${ENV_DIR}/BUILD_CONFIG_WHITELIST" ]; then
+    config_vars=$(cat "${ENV_DIR}/BUILD_CONFIG_WHITELIST")
+  fi
+
+  for config_var in $config_vars; do
+      if [ -r "${ENV_DIR}/${config_var}" ]; then
+          export "${config_var}=$(cat "${ENV_DIR}/${config_var}")"
+      fi
+  done
 fi
 
 # Calculate build command


### PR DESCRIPTION
Fixes issue with non-inclusive language used for `BUILD_CONFIG_WHITELIST`. The new config variable `BUILD_CONFIG_ALLOWLIST` should be used from now on. Backwards compatibility for `BUILD_CONFIG_WHITELIST` is available to avoid breaking existing user setups.