### PR TITLE
Fix CI setup [changelog skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ env:
   - HATCHET_BUILDPACK_BASE="https://github.com/heroku/heroku-buildpack-clojure.git"
   - SHUNIT_HOME="/tmp/shunit2-2.1.6"
   matrix:
-  - TEST_CMD="/tmp/testrunner/bin/run -c ."
+  - TEST_CMD="/tmp/testrunner/bin/run ."
   - TEST_CMD="bash etc/hatchet-test.sh"

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -9,6 +9,9 @@ _createBaseProject() {
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :repositories [["central-https" {:url "https://repo1.maven.org/maven2"}]
+                 ["clojars-https" {:url "https://clojars.org/repo/"}]]
+  :omit-default-repositories true
   :dependencies [[org.clojure/clojure "1.5.1"]]
   :main ^:skip-aot sample.core
   :target-path "target/%s"
@@ -32,6 +35,9 @@ _createLein2ProjectFile() {
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
+  :repositories [["central-https" {:url "https://repo1.maven.org/maven2"}]
+                 ["clojars-https" {:url "https://clojars.org/repo/"}]]
+  :omit-default-repositories true
   :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]]
   :min-lein-version "2.0.0"
@@ -48,6 +54,9 @@ _createUberJarProjectFile() {
   :url "http://clojure-getting-started.herokuapp.com"
   :license {:name "Eclipse Public License v1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :repositories [["central-https" {:url "https://repo1.maven.org/maven2"}]
+                 ["clojars-https" {:url "https://clojars.org/repo/"}]]
+  :omit-default-repositories true
   :dependencies [[org.clojure/clojure "1.6.0"]
                 [compojure "1.1.8"]
                 [ring/ring-jetty-adapter "1.2.2"]

--- a/test/lein_test.sh
+++ b/test/lein_test.sh
@@ -10,6 +10,9 @@ test_is_lein_2_positive() {
     :url "http://clojure-getting-started.herokuapp.com"
     :license {:name "Eclipse Public License v1.0"
               :url "http://www.eclipse.org/legal/epl-v10.html"}
+    :repositories [["central-https" {:url "https://repo1.maven.org/maven2"}]
+                   ["clojars-https" {:url "https://clojars.org/repo/"}]]
+    :omit-default-repositories true
     :dependencies [[org.clojure/clojure "1.6.0"]
                    [compojure "1.1.8"]
                    [ring/ring-jetty-adapter "1.2.2"]
@@ -30,6 +33,9 @@ test_is_lein_2_negative() {
     :url "http://clojure-getting-started.herokuapp.com"
     :license {:name "Eclipse Public License v1.0"
               :url "http://www.eclipse.org/legal/epl-v10.html"}
+   :repositories [["central-https" {:url "https://repo1.maven.org/maven2"}]
+                 ["clojars-https" {:url "https://clojars.org/repo/"}]]
+    :omit-default-repositories true
     :dependencies [[org.clojure/clojure "1.6.0"]
                    [compojure "1.1.8"]
                    [ring/ring-jetty-adapter "1.2.2"]
@@ -49,6 +55,9 @@ test_calculate_lein_build_task_uberjar() {
     :url "http://clojure-getting-started.herokuapp.com"
     :license {:name "Eclipse Public License v1.0"
               :url "http://www.eclipse.org/legal/epl-v10.html"}
+    :repositories [["central-https" {:url "https://repo1.maven.org/maven2"}]
+                   ["clojars-https" {:url "https://clojars.org/repo/"}]]
+    :omit-default-repositories true
     :dependencies [[org.clojure/clojure "1.6.0"]
                    [compojure "1.1.8"]
                    [ring/ring-jetty-adapter "1.2.2"]
@@ -72,6 +81,9 @@ test_calculate_lein_build_task_production_compile() {
     :url "http://clojure-getting-started.herokuapp.com"
     :license {:name "Eclipse Public License v1.0"
               :url "http://www.eclipse.org/legal/epl-v10.html"}
+    :repositories [["central-https" {:url "https://repo1.maven.org/maven2"}]
+                   ["clojars-https" {:url "https://clojars.org/repo/"}]]
+    :omit-default-repositories true
     :dependencies [[org.clojure/clojure "1.6.0"]
                    [compojure "1.1.8"]
                    [ring/ring-jetty-adapter "1.2.2"]


### PR DESCRIPTION
Allows CI to properly pass again.

Removes `-c` option for [testrunner](https://github.com/heroku/heroku-buildpack-testrunner), disabling support for [magic-curl](https://github.com/ryanbrainard/magic-curl) which breaks on more modern systems.

Also, certain Leiningen versions still use HTTP to access Maven Central and Clojars which is no longer supported. Test projects now explicitly override the default repositories with their HTTPS counterparts.