### PR TITLE
Remove heroku-16 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ orbs:
   heroku: circleci/heroku@1.1.1
 
 executors:
-  heroku-16:
-    docker:
-      - image: heroku/heroku:16
   heroku-18:
     docker:
       - image: heroku/heroku:18
@@ -19,7 +16,7 @@ jobs:
     parameters:
       heroku-stack:
         type: enum
-        enum: ["heroku-16", "heroku-18", "heroku-20"]
+        enum: ["heroku-18", "heroku-20"]
     docker:
       - image: circleci/ruby:2.7
     environment:
@@ -75,11 +72,10 @@ jobs:
           command: /tmp/testrunner/bin/run .
 
 workflows:
-  version: 2.1
   default-ci-workflow:
     jobs:
       - buildpack-testrunner
       - hatchet:
           matrix:
             parameters:
-              heroku-stack: ["heroku-16", "heroku-18", "heroku-20"]
+              heroku-stack: ["heroku-18", "heroku-20"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+* Remove heroku-16 testing
+
 ## v87
 
 * Enable heroku-20 testing


### PR DESCRIPTION
The Heroku-16 stack reached end of life on May 1st, 2021, and from June 1st, 2021, the ability to build will also be disabled. See: https://help.heroku.com/0S5P41DC/heroku-16-end-of-life-faq

As such after June 1st, Heroku-16 must be removed from the buildpack CI test matrix, so that CI on the repository continues to pass.

Closes [GUS-W-9329687](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000N0Q9YAK/view)