### PR TITLE
Feature: Support for deps.edn-only projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+* Add support for deps.edn (tools.deps) projects
 * Remove heroku-16 testing
 
 ## v87

--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 ![clojure](https://cloud.githubusercontent.com/assets/51578/13712844/d37ac78c-e793-11e5-9f0a-d033eb4f6f9f.png)
 
 This is the official [Heroku buildpack](http://devcenter.heroku.com/articles/buildpack) for Clojure apps. It uses
-[Leiningen](http://leiningen.org).
+[Leiningen](http://leiningen.org) or the [Clojure CLI tools](https://clojure.org/guides/deps_and_cli).
 
 Note that you don't have to do anything special to use this buildpack
 with Clojure apps on Heroku; it will be used by default for all
-projects containing a project.clj file, though it may be an older
+projects containing a project.clj or deps.edn file, though it may be an older
 revision than what you're currently looking at.
 
 ## How it works
 
 The buildpack will detect your app as Clojure if it has a
-`project.clj` file in the root. If you use the
+`project.clj` or `deps.edn` file in the root. If there are both files, it will
+use Leiningen.
+If you use the
 [clojure-maven-plugin](https://github.com/talios/clojure-maven-plugin),
 [the standard Java buildpack](http://github.com/heroku/heroku-buildpack-java)
 should work instead.
@@ -69,11 +71,36 @@ remote: Verifying deploy.... done.
 
 ## Configuration
 
+### Clojure CLI
+
+The default version of Clojure CLI tools installed is 1.10.3.1029.
+You can request something else by setting the config param
+`CLOJURE_CLI_VERSION` to something else.
+
+Your `Procfile` should declare what process types make up your app.
+Generally this is done with `:exec-fn` aliases in your `deps.edn` file.
+
+For example, if your `deps.edn` has something like this:
+
+```clojure
+{:aliases
+ {:web
+  {:exec-fn my.ns/run-web-server}}}
+```
+
+...then your `Procfile` should look like this:
+
+```
+web: clojure -X:web
+```
+
+### Leiningen
+
 Leiningen 1.7.1 will be used by default, but if you have
 `:min-lein-version "2.0.0"` in project.clj (highly recommended) then
 the latest Leiningen 2.x release will be used instead.
 
-Your `Procfile` should declare what process types which make up your
+Your `Procfile` should declare what process types make up your
 app. Often in development Leiningen projects are launched using `lein
 run -m my.project.namespace`, but this is not recommended in
 production because it leaves Leiningen running in addition to your

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ For example, if your `deps.edn` has something like this:
 web: clojure -X:web
 ```
 
+If your project is missing a `Procfile` the one above will generated
+automatically on deploy. So you can just setup a `:web` alias with the fn you
+want to run in its `:exec-fn` in your `deps.edn` file.
+
 ### Leiningen
 
 Leiningen 1.7.1 will be used by default, but if you have

--- a/bin/compile
+++ b/bin/compile
@@ -161,7 +161,7 @@ echo "       Running: $BUILD_COMMAND"
 
 cd $BUILD_DIR
 BUILD_PATH=$PATH
-if [ $BUILD_TOOL = "Leiningen" ]; then
+if [ "$BUILD_TOOL" = "Leiningen" ]; then
   BUILD_PATH=$(dirname $LEIN_BIN_PATH):$PATH
 fi
 PATH=$BUILD_PATH JVM_OPTS="-Xmx600m" \

--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,7 @@ detect_and_install_nodejs ${BUILD_DIR}
 install_rlwrap "${BUILD_DIR}" "${CACHE_DIR}"
 
 # Run clojure install script (clojure / clj may be needed from leiningen for newer cli tools)
-CLOJURE_CLI_VERSION="${CLOJURE_CLI_VERSION:-1.10.0.411}"
+CLOJURE_CLI_VERSION="${CLOJURE_CLI_VERSION:-1.10.3.1029}"
 echo "-----> Installing Clojure $CLOJURE_CLI_VERSION CLI tools"
 CLOJURE_INSTALL_NAME="linux-install-${CLOJURE_CLI_VERSION}.sh"
 CLOJURE_INSTALL_URL="https://download.clojure.org/install/$CLOJURE_INSTALL_NAME"

--- a/bin/compile
+++ b/bin/compile
@@ -41,71 +41,78 @@ mkdir -p $BUILD_DIR/.heroku/clj
 "/tmp/$CLOJURE_INSTALL_NAME" --prefix $BUILD_DIR/.heroku/clj 2>/dev/null | sed -u 's/^/       /'
 chmod +x $BUILD_DIR/.heroku/clj/bin/*
 export PATH=$BUILD_DIR/.heroku/clj/bin:$PATH
+CLOJURE_CLI_BUILD_COMMAND="clojure -P"
 
-# Check for vendored lein script
-if [ -x $BUILD_DIR/bin/lein ]; then
-  echo "-----> Using vendored Leiningen at bin/lein"
-  LEIN_BIN_PATH="$BUILD_DIR/bin/lein"
-  calculate_lein_build_task $BUILD_DIR
-  $LEIN_BIN_PATH version 2>/dev/null | sed -u 's/^/       /'
-else
-  # Determine Leiningen version
-  if is_lein_2 $BUILD_DIR; then
-    LEIN_VERSION="2.9.1"
-    LEIN_BIN_SOURCE="$(dirname $0)/../opt/lein2"
+if [ -f $BUILD_DIR/deps.edn && ! -f $BUILD_DIR/project.clj ]; then
+  BUILD_TOOL="Clojure CLI"
+elif [ -f $BUILD_DIR/project.clj ]; then
+  BUILD_TOOL="Leiningen"
+
+  # Check for vendored lein script
+  if [ -x $BUILD_DIR/bin/lein ]; then
+    echo "-----> Using vendored Leiningen at bin/lein"
+    LEIN_BIN_PATH="$BUILD_DIR/bin/lein"
     calculate_lein_build_task $BUILD_DIR
+    $LEIN_BIN_PATH version 2>/dev/null | sed -u 's/^/       /'
   else
-    LEIN_VERSION="1.7.1"
-    LEIN_BIN_SOURCE="$(dirname $0)/../opt/lein1"
-    LEIN_BUILD_TASK=${LEIN_BUILD_TASK:-"deps"}
-    if [ "$LEIN_DEV" = "" ]; then
-      export LEIN_NO_DEV=y
+    # Determine Leiningen version
+    if is_lein_2 $BUILD_DIR; then
+      LEIN_VERSION="2.9.1"
+      LEIN_BIN_SOURCE="$(dirname $0)/../opt/lein2"
+      calculate_lein_build_task $BUILD_DIR
+    else
+      LEIN_VERSION="1.7.1"
+      LEIN_BIN_SOURCE="$(dirname $0)/../opt/lein1"
+      LEIN_BUILD_TASK=${LEIN_BUILD_TASK:-"deps"}
+      if [ "$LEIN_DEV" = "" ]; then
+        export LEIN_NO_DEV=y
+      fi
+      RLWRAP=yes
+      warning "No :min-lein-version found in project.clj; using $LEIN_VERSION.
+    You probably don't want this!"
     fi
-    RLWRAP=yes
-    warning "No :min-lein-version found in project.clj; using $LEIN_VERSION.
-  You probably don't want this!"
+
+    # install leiningen jar
+    LEIN1_JAR_URL="https://lang-jvm.s3.amazonaws.com/leiningen-$LEIN_VERSION-standalone.jar"
+    LEIN2_JAR_URL="https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"
+    LEIN_JAR_CACHE_PATH="$CACHE_DIR/leiningen-$LEIN_VERSION-standalone.jar"
+    LEIN_JAR_SLUG_PATH="$BUILD_DIR/.lein/leiningen-$LEIN_VERSION-standalone.jar"
+
+    if [ "$LEIN_VERSION" = "1.7.1" ]; then
+      LEIN_JAR_URL=$LEIN1_JAR_URL
+    else
+      LEIN_JAR_URL=$LEIN2_JAR_URL
+    fi
+
+    if [ ! -r "$LEIN_JAR_CACHE_PATH" ]; then
+      echo "-----> Installing Leiningen"
+      echo "       Downloading: leiningen-$LEIN_VERSION-standalone.jar"
+      mkdir -p $(dirname $LEIN_JAR_CACHE_PATH)
+      curl --retry 3 --silent --show-error --max-time 120 -L -o "$LEIN_JAR_CACHE_PATH" $LEIN_JAR_URL
+    else
+      echo "-----> Using cached Leiningen $LEIN_VERSION"
+    fi
+
+    if [ "$LEIN_VERSION" = "1.7.1" ]; then
+      echo "       To use Leiningen 2.x, add this to project.clj: :min-lein-version \"2.0.0\""
+    fi
+
+    mkdir -p "$BUILD_DIR/.lein"
+    cp "$LEIN_JAR_CACHE_PATH" "$LEIN_JAR_SLUG_PATH"
+
+    # install lein script
+    LEIN_BIN_PATH=$BUILD_DIR"/.lein/bin/lein"
+    echo "       Writing: lein script"
+    mkdir -p $(dirname $LEIN_BIN_PATH)
+    cp $LEIN_BIN_SOURCE $LEIN_BIN_PATH
+    sed -i s/##LEIN_VERSION##/$LEIN_VERSION/ $LEIN_BIN_PATH
   fi
 
-  # install leiningen jar
-  LEIN1_JAR_URL="https://lang-jvm.s3.amazonaws.com/leiningen-$LEIN_VERSION-standalone.jar"
-  LEIN2_JAR_URL="https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"
-  LEIN_JAR_CACHE_PATH="$CACHE_DIR/leiningen-$LEIN_VERSION-standalone.jar"
-  LEIN_JAR_SLUG_PATH="$BUILD_DIR/.lein/leiningen-$LEIN_VERSION-standalone.jar"
-
-  if [ "$LEIN_VERSION" = "1.7.1" ]; then
-    LEIN_JAR_URL=$LEIN1_JAR_URL
-  else
-    LEIN_JAR_URL=$LEIN2_JAR_URL
-  fi
-
-  if [ ! -r "$LEIN_JAR_CACHE_PATH" ]; then
-    echo "-----> Installing Leiningen"
-    echo "       Downloading: leiningen-$LEIN_VERSION-standalone.jar"
-    mkdir -p $(dirname $LEIN_JAR_CACHE_PATH)
-    curl --retry 3 --silent --show-error --max-time 120 -L -o "$LEIN_JAR_CACHE_PATH" $LEIN_JAR_URL
-  else
-    echo "-----> Using cached Leiningen $LEIN_VERSION"
-  fi
-
-  if [ "$LEIN_VERSION" = "1.7.1" ]; then
-    echo "       To use Leiningen 2.x, add this to project.clj: :min-lein-version \"2.0.0\""
-  fi
-
-  mkdir -p "$BUILD_DIR/.lein"
-  cp "$LEIN_JAR_CACHE_PATH" "$LEIN_JAR_SLUG_PATH"
-
-  # install lein script
-  LEIN_BIN_PATH=$BUILD_DIR"/.lein/bin/lein"
-  echo "       Writing: lein script"
-  mkdir -p $(dirname $LEIN_BIN_PATH)
-  cp $LEIN_BIN_SOURCE $LEIN_BIN_PATH
-  sed -i s/##LEIN_VERSION##/$LEIN_VERSION/ $LEIN_BIN_PATH
+  # create user-level profiles
+  mkdir -p $BUILD_DIR/.lein
+  LEIN_PROFILES_SOURCE="$(dirname $0)/../opt/profiles.clj"
+  cp -n $LEIN_PROFILES_SOURCE "$BUILD_DIR/.lein/profiles.clj"
 fi
-
-# create user-level profiles
-mkdir -p $BUILD_DIR/.lein
-LEIN_PROFILES_SOURCE="$(dirname $0)/../opt/profiles.clj"
-cp -n $LEIN_PROFILES_SOURCE "$BUILD_DIR/.lein/profiles.clj"
 
 # unpack existing cache
 CACHED_DIRS=".m2 node_modules"
@@ -115,7 +122,7 @@ for DIR in $CACHED_DIRS; do
   fi
 done
 
-echo "-----> Building with Leiningen"
+echo "-----> Building with $BUILD_TOOL"
 
 # extract environment
 if [ -d "${ENV_DIR}" ]; then
@@ -139,12 +146,14 @@ fi
 
 # Calculate build command
 if [ "$BUILD_COMMAND" = "" ]; then
-    if [ -x $BUILD_DIR/bin/build ]; then
-        echo "       Found bin/build; running it instead of default lein invocation."
-        BUILD_COMMAND=bin/build
-    else
-        BUILD_COMMAND="lein $LEIN_BUILD_TASK"
-    fi
+  if [ -x $BUILD_DIR/bin/build ]; then
+    echo "       Found bin/build; running it instead of default lein/CLI invocation."
+    BUILD_COMMAND=bin/build
+  elif [ "$BUILD_TOOL" = "Leiningen" ]; then
+    BUILD_COMMAND="lein $LEIN_BUILD_TASK"
+  else
+    BUILD_COMMAND="$CLOJURE_CLI_BUILD_COMMAND"
+  fi
 fi
 
 echo "       Running: $BUILD_COMMAND"

--- a/bin/compile
+++ b/bin/compile
@@ -43,7 +43,7 @@ chmod +x $BUILD_DIR/.heroku/clj/bin/*
 export PATH=$BUILD_DIR/.heroku/clj/bin:$PATH
 CLOJURE_CLI_BUILD_COMMAND="clojure -P"
 
-if [ -f $BUILD_DIR/deps.edn && ! -f $BUILD_DIR/project.clj ]; then
+if [[ -f $BUILD_DIR/deps.edn && ! -f $BUILD_DIR/project.clj ]]; then
   BUILD_TOOL="Clojure CLI"
 elif [ -f $BUILD_DIR/project.clj ]; then
   BUILD_TOOL="Leiningen"

--- a/bin/compile
+++ b/bin/compile
@@ -17,6 +17,7 @@ LIB_DIR=$BP_DIR/lib
 
 source $LIB_DIR/common.sh
 source $LIB_DIR/lein.sh
+source $LIB_DIR/clojure-cli.sh
 source <(curl --retry 3 -fsSL $BUILDPACK_STDLIB_URL)
 
 export_env $ENV_DIR "." "JAVA_OPTS"
@@ -43,9 +44,9 @@ chmod +x $BUILD_DIR/.heroku/clj/bin/*
 export PATH=$BUILD_DIR/.heroku/clj/bin:$PATH
 CLOJURE_CLI_BUILD_COMMAND="clojure -P"
 
-if [[ -f $BUILD_DIR/deps.edn && ! -f $BUILD_DIR/project.clj ]]; then
+if is_tools_deps $BUILD_DIR; then
   BUILD_TOOL="Clojure CLI"
-elif [ -f $BUILD_DIR/project.clj ]; then
+else
   BUILD_TOOL="Leiningen"
 
   # Check for vendored lein script
@@ -159,7 +160,11 @@ fi
 echo "       Running: $BUILD_COMMAND"
 
 cd $BUILD_DIR
-PATH=$(dirname $LEIN_BIN_PATH):$PATH JVM_OPTS="-Xmx600m" \
+BUILD_PATH=$PATH
+if [ $BUILD_TOOL = "Leiningen" ]; then
+  BUILD_PATH=$(dirname $LEIN_BIN_PATH):$PATH
+fi
+PATH=$BUILD_PATH JVM_OPTS="-Xmx600m" \
   LEIN_JVM_OPTS="-Xmx400m -Duser.home=$BUILD_DIR" \
   $BUILD_COMMAND 2>&1 | sed -u 's/^/       /'
 if [ "${PIPESTATUS[*]}" != "0 0" ]; then

--- a/bin/detect
+++ b/bin/detect
@@ -6,9 +6,11 @@ if [ -f $1/project.clj ]; then
   if [ $? -eq 0 ]; then
     echo "Clojure (Leiningen 2)" && exit 0
   else
-    echo "Clojure" && exit 0
+    echo "Clojure (Leiningen 1)" && exit 0
   fi
+elif [ -f $1/deps.edn ]; then
+  echo "Clojure (tools.deps)" && exit 0
 else
-  (>&2 echo "Could not find a 'project.clj' file! Please ensure it exists and is checked into Git.")
+  (>&2 echo "Could not find a 'project.clj' or 'deps.edn' file! Please ensure one of them exists and is checked into Git.")
   exit 1
 fi

--- a/bin/release
+++ b/bin/release
@@ -9,6 +9,7 @@ LIB_DIR=$BP_DIR/lib
 
 source $LIB_DIR/common.sh
 source $LIB_DIR/lein.sh
+source $LIB_DIR/clojure-cli.sh
 
 if [ ! -f $BUILD_DIR/Procfile ]; then
   cat <<EOF
@@ -17,7 +18,10 @@ config_vars:
 default_process_types:
 EOF
 
-  if [ "$(calculate_lein_build_task $BUILD_DIR)" == "uberjar" ]; then
+  if is_tools_deps $BUILD_DIR; then
+    cd $BUILD_DIR
+    echo "  web: clojure -X:web"
+  elif [ "$(calculate_lein_build_task $BUILD_DIR)" == "uberjar" ]; then
     cd $BUILD_DIR
     for jarFile in $(find target -maxdepth 1 -name "*.jar" -type f); do
       echo "  web: java -jar $jarFile"

--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 # bin/test <build-dir> <env-dir> <artifact-dir>
 
-cd "$1" && lein test
+TEST_COMMAND="clojure -X:test"
+
+if [ -f $1/project.clj ]; then
+  TEST_COMMAND="lein test"
+fi
+
+cd "$1" && $TEST_COMMAND

--- a/lib/clojure-cli.sh
+++ b/lib/clojure-cli.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+is_tools_deps() {
+  local buildDir=${1}
+  if [[ -f $buildDir/deps.edn && ! -f $buildDir/project.clj ]]; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -44,7 +44,7 @@ install_nodejs() {
 detect_and_install_nodejs() {
   local buildDir=${1}
   if [ ! -d ${buildDir}/.heroku/nodejs ] && [ "true" != "$SKIP_NODEJS_INSTALL" ]; then
-    if [ "$(grep lein-npm ${buildDir}/project.clj)" != "" ] || [ -n "$NODEJS_VERSION"  ]; then
+    if [[ -f ${buildDir}/project.clj && "$(grep lein-npm ${buildDir}/project.clj)" != "" ]] || [ -n "$NODEJS_VERSION"  ]; then
       nodejsVersion=${NODEJS_VERSION:-4.2.1}
       echo "-----> Installing Node.js ${nodejsVersion}..."
       install_nodejs ${nodejsVersion} ${buildDir}/.heroku/nodejs 2>&1 | sed -u 's/^/       /'

--- a/test/spec/compile_spec.rb
+++ b/test/spec/compile_spec.rb
@@ -59,6 +59,7 @@ describe "Heroku's Clojure Support" do
   it "uses Clojure CLI when deps.edn present but no project.clj" do
     new_default_hatchet_runner("test/spec/fixtures/repos/cli-jdk-11").tap do |app|
       app.deploy do
+        expect(app.output).to include("Clojure (tools.deps) app detected")
         expect(app.output).to include("Installing JDK 11... done")
         expect(app.output).to include("Building with Clojure CLI")
         expect(app.output).to include("Running: clojure -P")

--- a/test/spec/compile_spec.rb
+++ b/test/spec/compile_spec.rb
@@ -55,4 +55,14 @@ describe "Heroku's Clojure Support" do
       end
     end
   end
+
+  it "uses Clojure CLI when deps.edn present but no project.clj" do
+    new_default_hatchet_runner("test/spec/fixtures/repos/cli-jdk-11").tap do |app|
+      app.deploy do
+        expect(app.output).to include("Installing JDK 11... done")
+        expect(app.output).to include("Building with Clojure CLI")
+        expect(app.output).to include("Running: clojure -P")
+      end
+    end
+  end
 end

--- a/test/spec/fixtures/repos/cli-jdk-11/deps.edn
+++ b/test/spec/fixtures/repos/cli-jdk-11/deps.edn
@@ -1,0 +1,1 @@
+{:deps {org.clojure/clojure {:mvn/version "1.10.3"}}}

--- a/test/spec/fixtures/repos/cli-jdk-11/src/sample/core.clj
+++ b/test/spec/fixtures/repos/cli-jdk-11/src/sample/core.clj
@@ -1,0 +1,5 @@
+(ns sample.core
+  (:gen-class))
+
+(defn -main [& args]
+  (println "Welcome to my Clojure CLI project! These are your args:" args))

--- a/test/spec/fixtures/repos/cli-jdk-11/system.properties
+++ b/test/spec/fixtures/repos/cli-jdk-11/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
Closes #75

This detects when projects only have a `deps.edn` file and uses the Clojure CLI tools to build and run the app instead of lein. I have tested it with one of my deps.edn apps and it is working there. 