### PR TITLE
Switch to the recommended regional S3 domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 
 * Vendor buildpack-stdlib rather than downloading it at build time
+* Switch to the recommended regional S3 domain instead of the global one
 
 ## v88
 

--- a/bin/compile
+++ b/bin/compile
@@ -67,7 +67,7 @@ else
   fi
 
   # install leiningen jar
-  LEIN1_JAR_URL="https://lang-jvm.s3.amazonaws.com/leiningen-$LEIN_VERSION-standalone.jar"
+  LEIN1_JAR_URL="https://lang-jvm.s3.us-east-1.amazonaws.com/leiningen-$LEIN_VERSION-standalone.jar"
   LEIN2_JAR_URL="https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"
   LEIN_JAR_CACHE_PATH="$CACHE_DIR/leiningen-$LEIN_VERSION-standalone.jar"
   LEIN_JAR_SLUG_PATH="$BUILD_DIR/.lein/leiningen-$LEIN_VERSION-standalone.jar"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -55,7 +55,7 @@ install_jdk() {
   local install_dir=${1}
 
   let start=$(nowms)
-  JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/jvm.tgz}
+  JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz}
   mkdir -p /tmp/jvm-common
   curl --retry 3 --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
   source /tmp/jvm-common/bin/util

--- a/test/spec/cljs_spec.rb
+++ b/test/spec/cljs_spec.rb
@@ -9,7 +9,7 @@ describe "ClojureScript" do
         end
 
         app.deploy do
-          expect(app.output).to include("Installing JDK #{DEFAULT_OPENJDK_VERSION}")
+          expect(app.output).to include("Installing OpenJDK #{DEFAULT_OPENJDK_VERSION}")
           expect(app.output).to match(/Downloading: leiningen-2.[5-9].[0-9]-standalone.jar/)
           expect(app.output).to include("Running: lein uberjar")
 
@@ -25,7 +25,7 @@ describe "ClojureScript" do
         end
 
         app.deploy do
-          expect(app.output).to include("Installing JDK #{DEFAULT_OPENJDK_VERSION}")
+          expect(app.output).to include("Installing OpenJDK #{DEFAULT_OPENJDK_VERSION}")
           expect(app.output).to match(/Downloading: leiningen-2.[5-9].[0-9]-standalone.jar/)
           expect(app.output).to include("Running: lein with-profile production do deps, compile :all")
 

--- a/test/spec/compile_spec.rb
+++ b/test/spec/compile_spec.rb
@@ -5,7 +5,7 @@ describe "Heroku's Clojure Support" do
   it "compiles a project without min-lein-version with JDK 1.7" do
     new_default_hatchet_runner("test/spec/fixtures/repos/lein-1-jdk-7").tap do |app|
       app.deploy do
-        expect(app.output).to include("Installing JDK 1.7... done")
+        expect(app.output).to include("Installing OpenJDK 1.7... done")
         expect(app.output).to include("No :min-lein-version found in project.clj; using 1.7.1.")
         expect(app.output).to include("To use Leiningen 2.x, add this to project.clj: :min-lein-version \"2.0.0\"")
         expect(app.output).to include("Downloading: leiningen-1.7.1-standalone.jar")
@@ -16,7 +16,7 @@ describe "Heroku's Clojure Support" do
   it "compiles a project without :min-lein-version with the default JDK version" do
     new_default_hatchet_runner("test/spec/fixtures/repos/lein-1-jdk-8").tap do |app|
       app.deploy do
-        expect(app.output).to include("Installing JDK 1.8... done")
+        expect(app.output).to include("Installing OpenJDK 1.8... done")
         expect(app.output).to include("No :min-lein-version found in project.clj; using 1.7.1.")
         expect(app.output).to include("To use Leiningen 2.x, add this to project.clj: :min-lein-version \"2.0.0\"")
         expect(app.output).to include("Downloading: leiningen-1.7.1-standalone.jar")
@@ -27,7 +27,7 @@ describe "Heroku's Clojure Support" do
   it "compiles a project with :min-lein-version set to 2.0.0 with the default JDK version" do
     new_default_hatchet_runner("test/spec/fixtures/repos/lein-2-jdk-8").tap do |app|
       app.deploy do
-        expect(app.output).to include("Installing JDK 1.8... done")
+        expect(app.output).to include("Installing OpenJDK 1.8... done")
         expect(app.output).to include("Downloading: leiningen-2.9.1-standalone.jar")
         expect(app.output).not_to include("WARNING: no :min-lein-version found in project.clj; using 1.7.1.")
       end
@@ -37,7 +37,7 @@ describe "Heroku's Clojure Support" do
   it "runs `lein uberjar` when the project has a :uberjar-name setting" do
     new_default_hatchet_runner("test/spec/fixtures/repos/lein-2-jdk-8-uberjar").tap do |app|
       app.deploy do
-        expect(app.output).to include("Installing JDK 1.8... done")
+        expect(app.output).to include("Installing OpenJDK 1.8... done")
         expect(app.output).to include("Running: lein uberjar")
       end
     end

--- a/test/spec/compojure_spec.rb
+++ b/test/spec/compojure_spec.rb
@@ -9,7 +9,7 @@ describe "Compojure" do
         end
 
         app.deploy do
-          expect(app.output).to include("Installing JDK #{DEFAULT_OPENJDK_VERSION}")
+          expect(app.output).to include("Installing OpenJDK #{DEFAULT_OPENJDK_VERSION}")
           expect(app.output).to match(/Downloading: leiningen-2.[0-9].[0-9]-standalone.jar/)
           expect(app.output).to include("Running: lein uberjar")
           expect(http_get(app)).to include('["Hello" :from Heroku]')


### PR DESCRIPTION
Whilst the global S3 endpoint (`s3.amazonaws.com`) still works, AWS now recommends using the appropriate regional endpoint to access the bucket:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#s3-legacy-endpoints

Our buildpack buckets are in `us-east-1`, whose regional domain is `*.s3.us-east-1.amazonaws.com`:
https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region

GUS-W-11283397.