### PR TITLE
Adjust curl retry and connection timeout handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
             sudo apt-get install file
       - run:
           name: Download and unpack shunit 2.1.6
-          command: curl -sSf https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/shunit2/shunit2-2.1.6.tgz | tar xz -C /tmp/
+          command: curl -sSf --retry 3 --retry-connrefused --connect-timeout 5 https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/shunit2/shunit2-2.1.6.tgz | tar xz -C /tmp/
       - run:
           name: Clone heroku-buildpack-testrunner
           command: git clone https://github.com/heroku/heroku-buildpack-testrunner.git /tmp/testrunner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+* Adjust curl retry and connection timeout handling
 * Vendor buildpack-stdlib rather than downloading it at build time
 * Switch to the recommended regional S3 domain instead of the global one
 

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ CLOJURE_CLI_VERSION="${CLOJURE_CLI_VERSION:-1.10.0.411}"
 echo "-----> Installing Clojure $CLOJURE_CLI_VERSION CLI tools"
 CLOJURE_INSTALL_NAME="linux-install-${CLOJURE_CLI_VERSION}.sh"
 CLOJURE_INSTALL_URL="https://download.clojure.org/install/$CLOJURE_INSTALL_NAME"
-curl --retry 3 -sfL --max-time 60 -o "/tmp/$CLOJURE_INSTALL_NAME" "$CLOJURE_INSTALL_URL"
+curl --retry 3 --retry-connrefused --connect-timeout 5 -sfL --max-time 60 -o "/tmp/$CLOJURE_INSTALL_NAME" "$CLOJURE_INSTALL_URL"
 chmod +x /tmp/$CLOJURE_INSTALL_NAME
 mkdir -p $BUILD_DIR/.heroku/clj
 "/tmp/$CLOJURE_INSTALL_NAME" --prefix $BUILD_DIR/.heroku/clj 2>/dev/null | sed -u 's/^/       /'
@@ -82,7 +82,7 @@ else
     echo "-----> Installing Leiningen"
     echo "       Downloading: leiningen-$LEIN_VERSION-standalone.jar"
     mkdir -p $(dirname $LEIN_JAR_CACHE_PATH)
-    curl --retry 3 --silent --show-error --max-time 120 -L -o "$LEIN_JAR_CACHE_PATH" $LEIN_JAR_URL
+    curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --show-error --max-time 120 -L -o "$LEIN_JAR_CACHE_PATH" $LEIN_JAR_URL
   else
     echo "-----> Using cached Leiningen $LEIN_VERSION"
   fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -20,8 +20,8 @@ install_nodejs() {
   local platform="$os-$cpu"
 
   echo "Resolving node version $version..."
-  if ! read number url < <(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt"); then
-    local error=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt")
+  if ! read number url < <(curl --silent --get --retry 5 --retry-max-time 15 --retry-connrefused --connect-timeout 5 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt"); then
+    local error=$(curl --silent --get --retry 5 --retry-max-time 15 --retry-connrefused --connect-timeout 5 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt")
     if [[ $error = "No result" ]]; then
       echo "Could not find Node version corresponding to version requirement: $version";
     else
@@ -30,7 +30,7 @@ install_nodejs() {
   fi
 
   echo "Downloading and installing node $version..."
-  local code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
+  local code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 --retry-connrefused --connect-timeout 5 -o /tmp/node.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
     echo "Unable to download node: $code" && false
   fi
@@ -57,7 +57,7 @@ install_jdk() {
   let start=$(nowms)
   JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz}
   mkdir -p /tmp/jvm-common
-  curl --retry 3 --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
+  curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
   source /tmp/jvm-common/bin/util
   source /tmp/jvm-common/bin/java
   source /tmp/jvm-common/opt/jdbc.sh


### PR DESCRIPTION
In the shimmed CNBs used in `heroku/builder` we have been seeing quite a few transient errors related to buildpacks downloading from S3.

Adding appropriate retries and connection timeouts to all of our buildpack's curl usages should help with these, as well as make builds more reliable in general for users on Heroku, plus also anyone using a shimmed CNB locally with Pack CLI (where the network connection may be even less reliable).

The `--retry-connrefused` option has been used since otherwise curl doesn't retry cases where the connection was refused. Ideally we would use `--retry-all-errors` which takes that one step further, however that option was only added in curl 7.71, so is only supported by Heroku-22+.

For more on curl options, see:
https://curl.se/docs/manpage.html

GUS-W-11283397.