### PR TITLE
Fix compatibility with the `heroku/google-chrome` buildpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+## v90
+
+* Fix compatibility with the `heroku/google-chrome` buildpack. ([#122](https://github.com/heroku/heroku-buildpack-clojure/pull/122)).
+
 ## v89
 
 * Adjust curl retry and connection timeout handling

--- a/lib/lein.sh
+++ b/lib/lein.sh
@@ -25,8 +25,8 @@ install_rlwrap() {
   local buildDir="${1:?}"
   local cacheDir="${2:?}"
 
-  APT_CACHE_DIR="$cacheDir/apt/cache"
-  APT_STATE_DIR="$cacheDir/apt/state"
+  APT_CACHE_DIR="$cacheDir/clojure-bp-apt/cache"
+  APT_STATE_DIR="$cacheDir/clojure-bp-apt/state"
   APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
 
   mkdir -p "$APT_CACHE_DIR/archives/partial"

--- a/test/spec/compatibility_spec.rb
+++ b/test/spec/compatibility_spec.rb
@@ -1,0 +1,14 @@
+require_relative "spec_helper"
+
+describe "Heroku's Clojure Support" do
+
+  it "successfully compiles a project when the heroku/google-chrome buildpack is also used" do
+    new_default_hatchet_runner("test/spec/fixtures/repos/lein-2-jdk-8", buildpacks: ["heroku/google-chrome", :default]).tap do |app|
+      app.deploy do
+        expect(app.output).to include("Google Chrome app detected")
+        expect(app.output).to include("Installing OpenJDK 1.8... done")
+        expect(app.output).to include("Downloading: leiningen-2.9.1-standalone.jar")
+      end
+    end
+  end
+end


### PR DESCRIPTION
When this buildpack is used together with the `heroku/google-chrome` buildpack, the build will eventually fail with an error like this:

```
chmod: cannot operate on dangling symlink '/tmp/build_34fcaac1/.heroku/apt/usr/bin/google-chrome-stable'
```

This happens because both buildpacks use the same directory in the buildpack cache directory for their apt cache and state dir. The Clojure buildpack will re-use the state and cache dir from the Chrome buildpack and install all packages that buildpack installed agin, but into a different directory. This means that not only the build will fail because we try to `chmod +x` a dangling symlink that is installed by the Chrome `.deb`, but also that the slug size will be increase greatly as we installed Chrome and its dependencies twice.

I consider the dangling symlink an issue of the `heroku/google-chome` buildpack (if at all) so there is no attempt made here to fix the symlink, but instead fix the root cause: apt cache and state dir collisions between these two buildpacks. I added an integration test for this case.

Changelog was updated for immediate release.

Closes GUS-W-11389779