### PR TITLE
Allow manual CI dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `workflow_dispatch` as a trigger for the `ci` workflow. 

When an outside collaborator opens a PR, that PR will run without any secrets present causing the Hatchet jobs to fail. This is good from a security standpoint, but to move forward with a PR, we want to verify that CI passes. Branch protection rules wouldn't allow to merge the PR with failed jobs anyway. This affects @dependabot as well.

By allowing a manual dispatch, the job will be run with the permissions of the person initiating the manual dispatch. After inspecting the PR for secret exfiltration and the like, maintainers can move forward with a PR from an outside collaborator. It is important to note that triggering a re-run of the failed workflow as an actor with elevated permissions _will not change the permissions for that re-run_ as stated in the docs:

> These restrictions apply even if the workflow is re-run by a different actor.

If would also be possible to work around this issue for @dependabot by using a conditional workflow just for @dependabot with the `pull_request_target` trigger. I opted not to do that since this doesn't fix the issue when outside (human) collaborators open a PR. If we want to simplify @dependabot PRs specifically, we can duplicate the required secrets to the @dependabot secrets which will be available in the workflow ([ref](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events)). This can be done outside of this PR.

Refs:
- https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
- https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-797125425