### PR TITLE
Remove heroku-18 stack support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack: ["heroku-18", "heroku-20", "heroku-22"]
+        stack: ["heroku-20", "heroku-22"]
     env:
       HATCHET_APP_LIMIT: 100
       HATCHET_RUN_MULTI: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+* Remove heroku-18 support ([#140](https://github.com/heroku/heroku-buildpack-clojure/pull/140))
+
 ## v90
 
 * Fix compatibility with the `heroku/google-chrome` buildpack. ([#122](https://github.com/heroku/heroku-buildpack-clojure/pull/122)).


### PR DESCRIPTION
Since the Heroku-18 stack has reached end-of-life, and as such builds using it are no longer supported by the Heroku build system:
https://devcenter.heroku.com/changelog-items/2583

This fixes the integration tests failing in CI for the Heroku-18 stack, due to the build system now (as expected) rejecting the jobs.

Any non-Heroku consumers of this buildpack that wish to continue using the Heroku-18 stack should pin to the previous version of this buildpack.

Ref: GUS-W-10446298