### PR TITLE
Drop dependency on nodebin.herokai.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+* Drop dependency on Node.js version resolver service, nodebin.herokai.com ([#143](https://github.com/heroku/heroku-buildpack-clojure/pull/143))
 * Remove heroku-18 support ([#140](https://github.com/heroku/heroku-buildpack-clojure/pull/140))
 
 ## v90

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -15,27 +15,17 @@ cache_copy() {
 install_nodejs() {
   local version="${1:?}"
   local dir="${2:?}"
-  local os="linux"
-  local cpu="x64"
-  local platform="$os-$cpu"
+  local url="https://heroku-nodebin-staging.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v${version}-linux-x64.tar.gz"
 
-  echo "Resolving node version $version..."
-  if ! read number url < <(curl --silent --get --retry 5 --retry-max-time 15 --retry-connrefused --connect-timeout 5 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt"); then
-    local error=$(curl --silent --get --retry 5 --retry-max-time 15 --retry-connrefused --connect-timeout 5 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt")
-    if [[ $error = "No result" ]]; then
-      echo "Could not find Node version corresponding to version requirement: $version";
-    else
-      echo "Error: Invalid semantic version \"$version\""
-    fi
-  fi
-
-  echo "Downloading and installing node $version..."
+  echo "Downloading Node.js $version..."
   local code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 --retry-connrefused --connect-timeout 5 -o /tmp/node.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
-    echo "Unable to download node: $code" && false
+    echo "Unable to download Node.js version ${version}: $code"
+    return false
   fi
+
   tar xzf /tmp/node.tar.gz -C /tmp
-  mv /tmp/node-v$version-$os-$cpu $dir
+  mv /tmp/node-v$version-linux-x64 $dir
   chmod +x $dir/bin/*
 }
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -33,7 +33,7 @@ detect_and_install_nodejs() {
   local buildDir=${1}
   if [ ! -d ${buildDir}/.heroku/nodejs ] && [ "true" != "$SKIP_NODEJS_INSTALL" ]; then
     if [ "$(grep lein-npm ${buildDir}/project.clj)" != "" ] || [ -n "$NODEJS_VERSION"  ]; then
-      nodejsVersion=${NODEJS_VERSION:-4.2.1}
+      nodejsVersion=${NODEJS_VERSION:-18.16.0}
       echo "-----> Installing Node.js ${nodejsVersion}..."
       install_nodejs ${nodejsVersion} ${buildDir}/.heroku/nodejs 2>&1 | sed -u 's/^/       /'
       export PATH=${buildDir}/.heroku/nodejs/bin:$PATH

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -15,7 +15,7 @@ cache_copy() {
 install_nodejs() {
   local version="${1:?}"
   local dir="${2:?}"
-  local url="https://heroku-nodebin-staging.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v${version}-linux-x64.tar.gz"
+  local url="https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v${version}-linux-x64.tar.gz"
 
   echo "Downloading Node.js $version..."
   local code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 --retry-connrefused --connect-timeout 5 -o /tmp/node.tar.gz --write-out "%{http_code}")


### PR DESCRIPTION
The Node.js version resolver service, nodebin.herokai.com is being retired, as documented here. https://devcenter.heroku.com/changelog-items/2598.

This PR drops the dependency on the version resolver service, relying on the nodebin S3 bucket directly instead (this is where the official Node.js buildpack downloads from as well).

This PR also updates the default Node.js version to the current Active LTS. The default version was pointed at a 2017 release, that is well past end-of-life.