### PR TITLE
Dont suppress errors during Clojure download

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ CLOJURE_CLI_VERSION="${CLOJURE_CLI_VERSION:-1.10.0.411}"
 echo "-----> Installing Clojure $CLOJURE_CLI_VERSION CLI tools"
 CLOJURE_INSTALL_NAME="linux-install-${CLOJURE_CLI_VERSION}.sh"
 CLOJURE_INSTALL_URL="https://download.clojure.org/install/$CLOJURE_INSTALL_NAME"
-curl --retry 3 --retry-connrefused --connect-timeout 5 -sfL --max-time 60 -o "/tmp/$CLOJURE_INSTALL_NAME" "$CLOJURE_INSTALL_URL"
+curl --retry 3 --retry-connrefused --connect-timeout 5 -sSfL --max-time 60 -o "/tmp/$CLOJURE_INSTALL_NAME" "$CLOJURE_INSTALL_URL"
 chmod +x /tmp/$CLOJURE_INSTALL_NAME
 mkdir -p $BUILD_DIR/.heroku/clj
 "/tmp/$CLOJURE_INSTALL_NAME" --prefix $BUILD_DIR/.heroku/clj 2>/dev/null | sed -u 's/^/       /'


### PR DESCRIPTION
Currently, when the download of the Clojure CLI fails the actual error is not surfaced. This makes debugging much harder, especially when intermittent network errors are the cause. This PR adds `-S` to the `curl` command, surfacing errors to the build log.

Before:

```
remote:        Need to get 0 B/98.2 kB of archives.
remote:        After this operation, 309 kB of additional disk space will be used.
remote:        Download complete and in download only mode
remote: -----> Installing Clojure foobar CLI tools
remote:  !     Push rejected, failed to compile Clojure (Leiningen 2) app.
remote:
remote:  !     Push failed
```

After:

```
remote:        Need to get 0 B/98.2 kB of archives.
remote:        After this operation, 309 kB of additional disk space will be used.
remote:        Download complete and in download only mode
remote: -----> Installing Clojure foobar CLI tools
remote: curl: (22) The requested URL returned error: 403
remote:  !     Push rejected, failed to compile Clojure (Leiningen 2) app.
remote:
remote:  !     Push failed
```

Closes: GUS-W-13879339