### PR TITLE
Add heroku-26 to hatchet CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack: ["heroku-22", "heroku-24"]
+        stack: ["heroku-22", "heroku-24", "heroku-26"]
     env:
       HATCHET_APP_LIMIT: 100
       HATCHET_RUN_MULTI: 1


### PR DESCRIPTION
Adds the `heroku-26` stack to the hatchet CI matrix.

GUS-W-20775991