### PR TITLE
Update slug size expectations in hatchet tests

### DIFF
--- a/test/spec/compile_spec.rb
+++ b/test/spec/compile_spec.rb
@@ -131,7 +131,7 @@ describe 'Clojure' do
           remote:        Default types for buildpack -> web
 
           remote: -----> Compressing...
-          remote:        Done: 111.3M
+          remote:        Done: 111.4M
         OUTPUT
 
         app.commit!
@@ -164,7 +164,7 @@ describe 'Clojure' do
           remote:        Default types for buildpack -> web
 
           remote: -----> Compressing...
-          remote:        Done: 111.3M
+          remote:        Done: 111.4M
         OUTPUT
       end
     end
@@ -296,7 +296,7 @@ describe 'Clojure' do
           remote:        Default types for buildpack -> web
 
           remote: -----> Compressing...
-          remote:        Done: 108.8M
+          remote:        Done: 109M
         OUTPUT
 
         app.commit!
@@ -327,7 +327,7 @@ describe 'Clojure' do
           remote:        Default types for buildpack -> web
 
           remote: -----> Compressing...
-          remote:        Done: 108.8M
+          remote:        Done: 109M
         OUTPUT
       end
     end


### PR DESCRIPTION
The expected slug sizes in the hatchet tests drifted from the actual values produced by recent builds, causing failures across all stacks. This updates the expectations to match.