### PR TITLE
Show Clojure CLI installer stderr in build output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Show Clojure CLI installer stderr in build output instead of discarding it. ([#228](https://github.com/heroku/heroku-buildpack-clojure/pull/228))
 
 ## [v97] - 2026-03-31
 

--- a/bin/compile
+++ b/bin/compile
@@ -67,7 +67,7 @@ if [[ "$(realpath "${BUILD_DIR}")" != "$(realpath /app)" ]]; then
 	ln -nsf "${BUILD_DIR}/${CLOJURE_CLI_DIR}" "/app/${CLOJURE_CLI_DIR}"
 fi
 
-"${CLOJURE_INSTALL_SCRIPT}" --prefix "/app/${CLOJURE_CLI_DIR}" 2>/dev/null | output::indent
+"${CLOJURE_INSTALL_SCRIPT}" --prefix "/app/${CLOJURE_CLI_DIR}" |& output::indent
 chmod +x "/app/${CLOJURE_CLI_DIR}/bin/"*
 export PATH="/app/${CLOJURE_CLI_DIR}/bin:${PATH}"
 


### PR DESCRIPTION
The Clojure CLI installer's stderr was discarded with `2>/dev/null`, hiding diagnostic output when the installer fails. It was suppressed before because the installer was printing curl progress output, but it now uses curl flags that don't produce noisy output (After an upstream change we encouragged). Switching to `|&` pipes both streams through `output::indent` so errors are visible in build logs.

W-19154642